### PR TITLE
Always retry alternatives.install states

### DIFF
--- a/rider/linuxenv.sls
+++ b/rider/linuxenv.sls
@@ -31,6 +31,9 @@ rider-home-alt-install:
     - link: '{{ rider.jetbrains.home }}/rider'
     - path: '{{ rider.jetbrains.realhome }}'
     - priority: {{ rider.linux.altpriority }}
+    - retry:
+        attempts: 2
+        until: True
 
 rider-home-alt-set:
   alternatives.set:
@@ -38,6 +41,9 @@ rider-home-alt-set:
     - path: {{ rider.jetbrains.realhome }}
     - onchanges:
       - alternatives: rider-home-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
 # Add to alternatives system
 rider-alt-install:
@@ -49,6 +55,9 @@ rider-alt-install:
     - require:
       - alternatives: rider-home-alt-install
       - alternatives: rider-home-alt-set
+    - retry:
+        attempts: 2
+        until: True
 
 rider-alt-set:
   alternatives.set:
@@ -56,6 +65,9 @@ rider-alt-set:
     - path: {{ rider.jetbrains.realcmd }}
     - onchanges:
       - alternatives: rider-alt-install
+    - retry:
+        attempts: 2
+        until: True
 
   {% endif %}
 

--- a/rider/map.jinja
+++ b/rider/map.jinja
@@ -22,10 +22,10 @@
 {% endif %}
 
 # Get dynamic release metadata
-{%- set pcode = pcode ~ ide.jetbrains.edition %}
-{% if grains.os == 'MacOS' or ide.jetbrains.edition in ('None',) %}
-   {%- set pcode = ide.jetbrains.product %}
-{% endif %}
+{%- set pcode = ide.jetbrains.product %}
+{%- if grains.os != 'MacOS' %}
+    {%- set pcode = pcode ~ ide.jetbrains.edition if ide.jetbrains.edition else pcode %}
+{%- endif %}
 {%- set jdata = salt['cmd.run']('curl {0} {1}{2}'.format(ide.dl.opts, ide.jetbrains.uri, pcode))|load_yaml %}
 
 # Extract download details


### PR DESCRIPTION
This PR introduces retries because salt `alternatives.install` always fails on 1st run.

Verified on SuSE


```
          ID: rider-home-alt-install
    Function: alternatives.install
        Name: rider-home
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for rider-home not installed: update-alternatives: using /usr/local/jetbrains/rider-2018.3.4 to provide /opt/jetbrains/rider (rider-home) in auto mode"
              Alternatives for rider-home is already set to /usr/local/jetbrains/rider-2018.3.4
     Started: 23:31:43.724667
    Duration: 30157.861 ms
     Changes:   
----------
          ID: rider-home-alt-set
    Function: alternatives.set
        Name: rider-home
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:   
----------
          ID: rider-alt-install
    Function: alternatives.install
        Name: rider
      Result: True
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Alternative for rider not installed: update-alternatives: using /usr/local/jetbrains/rider-2018.3.4/bin/rider.sh to provide /usr/bin/rider (rider) in auto mode"
              Alternatives for rider is already set to /usr/local/jetbrains/rider-2018.3.4/bin/rider.sh
     Started: 23:32:13.908920
    Duration: 30017.396 ms
     Changes:   
----------
          ID: rider-alt-set
    Function: alternatives.set
        Name: rider
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Changes:
```